### PR TITLE
Custom Requests Refactor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "composer-runtime-api": "^2",
         "filp/whoops": "^2.14",
         "laminas/laminas-diactoros": "^2.8",
-        "noctis/kickstart": "dev-feature/custom-requests-refactor",
+        "noctis/kickstart": "~4.0.0",
         "paragonie/easydb": "^2.11|^3.0",
         "php-di/php-di": "^6.3",
         "psr/container": "^1.1|^2.0",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "composer-runtime-api": "^2",
         "filp/whoops": "^2.14",
         "laminas/laminas-diactoros": "^2.8",
-        "noctis/kickstart": "~3.2.0",
+        "noctis/kickstart": "dev-feature/custom-requests-refactor",
         "paragonie/easydb": "^2.11|^3.0",
         "php-di/php-di": "^6.3",
         "psr/container": "^1.1|^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c614341f635588a8916bd7b39ebcb408",
+    "content-hash": "901095c8212495942cd5c3317ad9a4f3",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -620,16 +620,16 @@
         },
         {
             "name": "noctis/kickstart",
-            "version": "dev-feature/custom-requests-refactor",
+            "version": "4.0.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Noctis/kickstart.git",
-                "reference": "6918b5a12d9250c2fcc74a0a104e8ce3cb0e4a78"
+                "reference": "4ccdfcad5e3d4fa49995c8fe6400b7ef04c7a071"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Noctis/kickstart/zipball/6918b5a12d9250c2fcc74a0a104e8ce3cb0e4a78",
-                "reference": "6918b5a12d9250c2fcc74a0a104e8ce3cb0e4a78",
+                "url": "https://api.github.com/repos/Noctis/kickstart/zipball/4ccdfcad5e3d4fa49995c8fe6400b7ef04c7a071",
+                "reference": "4ccdfcad5e3d4fa49995c8fe6400b7ef04c7a071",
                 "shasum": ""
             },
             "require": {
@@ -656,6 +656,7 @@
                 "symfony/var-dumper": "^5.4",
                 "vimeo/psalm": "^4.19"
             },
+            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -680,9 +681,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Noctis/kickstart/issues",
-                "source": "https://github.com/Noctis/kickstart/tree/feature/custom-requests-refactor"
+                "source": "https://github.com/Noctis/kickstart/tree/4.0.x"
             },
-            "time": "2022-07-19T12:52:43+00:00"
+            "time": "2022-07-26T07:36:21+00:00"
         },
         {
             "name": "opis/closure",
@@ -4266,7 +4267,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "noctis/kickstart": 20,
         "roave/security-advisories": 20
     },
     "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5898497478c604e9c5c40358ae86daa9",
+    "content-hash": "c614341f635588a8916bd7b39ebcb408",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -620,16 +620,16 @@
         },
         {
             "name": "noctis/kickstart",
-            "version": "3.2.0",
+            "version": "dev-feature/custom-requests-refactor",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Noctis/kickstart.git",
-                "reference": "35a56e04551c0f8d7ff198b75d1f0e023de1c0e3"
+                "reference": "6918b5a12d9250c2fcc74a0a104e8ce3cb0e4a78"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Noctis/kickstart/zipball/35a56e04551c0f8d7ff198b75d1f0e023de1c0e3",
-                "reference": "35a56e04551c0f8d7ff198b75d1f0e023de1c0e3",
+                "url": "https://api.github.com/repos/Noctis/kickstart/zipball/6918b5a12d9250c2fcc74a0a104e8ce3cb0e4a78",
+                "reference": "6918b5a12d9250c2fcc74a0a104e8ce3cb0e4a78",
                 "shasum": ""
             },
             "require": {
@@ -680,9 +680,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Noctis/kickstart/issues",
-                "source": "https://github.com/Noctis/kickstart/tree/3.2.0"
+                "source": "https://github.com/Noctis/kickstart/tree/feature/custom-requests-refactor"
             },
-            "time": "2022-07-21T07:57:30+00:00"
+            "time": "2022-07-19T12:52:43+00:00"
         },
         {
             "name": "opis/closure",
@@ -796,28 +796,28 @@
         },
         {
             "name": "paragonie/easydb",
-            "version": "v3.0.2",
+            "version": "v2.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/easydb.git",
-                "reference": "b8d12d444ca84010f5f48ceacb39d3f2822f0c6f"
+                "reference": "38cfac4bbd96960628ca3237ed98f3f344ffdd7b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/easydb/zipball/b8d12d444ca84010f5f48ceacb39d3f2822f0c6f",
-                "reference": "b8d12d444ca84010f5f48ceacb39d3f2822f0c6f",
+                "url": "https://api.github.com/repos/paragonie/easydb/zipball/38cfac4bbd96960628ca3237ed98f3f344ffdd7b",
+                "reference": "38cfac4bbd96960628ca3237ed98f3f344ffdd7b",
                 "shasum": ""
             },
             "require": {
                 "ext-pdo": "*",
-                "paragonie/corner": "^2",
-                "php": "^8"
+                "paragonie/corner": "^1|^2",
+                "php": "^7|^8"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9",
+                "phpunit/phpunit": "^6|^7",
                 "psalm/plugin-phpunit": "<1",
                 "squizlabs/php_codesniffer": "^3",
-                "vimeo/psalm": "^4"
+                "vimeo/psalm": "^3"
             },
             "type": "library",
             "autoload": {
@@ -831,8 +831,8 @@
             ],
             "authors": [
                 {
-                    "name": "Paragon Initiative Enterprises",
-                    "email": "security@paragonie.com",
+                    "name": "Scott Arciszewski",
+                    "email": "scott@paragonie.com",
                     "homepage": "https://paragonie.com",
                     "role": "Developer"
                 },
@@ -859,7 +859,7 @@
                 "issues": "https://github.com/paragonie/easydb/issues",
                 "source": "https://github.com/paragonie/easydb"
             },
-            "time": "2022-06-08T05:23:05+00:00"
+            "time": "2020-01-20T01:06:56+00:00"
         },
         {
             "name": "php-di/invoker",
@@ -4266,6 +4266,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "noctis/kickstart": 20,
         "roave/security-advisories": 20
     },
     "prefer-stable": true,

--- a/docs/Custom_Http_Requests.md
+++ b/docs/Custom_Http_Requests.md
@@ -43,7 +43,7 @@ return [
 ];
 ```
 
-An instance of your custom request's class will be provided to the HTTP action through its `execute()` method, as the
+An instance of your custom request's class will be provided to the HTTP action through its `process()` method, as the
 `$request` variable:
 
 ```php

--- a/docs/Custom_Http_Requests.md
+++ b/docs/Custom_Http_Requests.md
@@ -2,7 +2,8 @@
 
 If you wish to add your own, additional methods to a request object, you can do so by creating a custom HTTP request
 object, which acts as decorator around the original request. Your custom HTTP request class must extend the
-`Noctis\KickStart\Http\Request\AbstractRequest` abstract class:
+`Noctis\KickStart\Http\Request\Request` class and implement [PSR-7's](https://www.php-fig.org/psr/psr-7/) 
+`Psr\Http\Message\ServerRequestInterface` interface:
 
 ```php
 <?php
@@ -11,9 +12,10 @@ declare(strict_types=1);
 
 namespace App\Http\Request;
 
-use Noctis\KickStart\Http\Request\AbstractRequest;
+use Noctis\KickStart\Http\Request\Request;
+use Psr\Http\Message\ServerRequestInterface;
 
-final class DummyRequest extends AbstractRequest
+final class DummyRequest extends Request implements ServerRequestInterface
 {
     public function getFoo(): string
     {
@@ -22,7 +24,27 @@ final class DummyRequest extends AbstractRequest
 }
 ```
 
-You can then inject your custom HTTP request object into an HTTP action class, through its constructor:
+You must then provide your custom request's class name in the route definition for your action. Routes list can be found
+in your application's `src/Http/Routing/routes.php` file. Custom request's class name must be provided as the route's
+4th argument, for example:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Action\DummyAction;
+use App\Http\Middleware\Guard\DummyGuard;
+use App\Http\Request\DummyRequest;
+use Noctis\KickStart\Http\Routing\Route;
+
+return [
+    Route::get('/', DummyAction::class, [DummyGuard::class], DummyRequest::class),
+];
+```
+
+An instance of your custom request's class will be provided to the HTTP action through its `execute()` method, as the
+`$request` variable:
 
 ```php
 <?php
@@ -39,12 +61,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 final class DummyAction implements ActionInterface
 {
-    private DummyRequest $request;
-
-    public function __construct(DummyRequest $request) 
-    {
-        $this->request = $request;
-    }
+    // ...
     
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): HtmlResponse
     {
@@ -53,62 +70,83 @@ final class DummyAction implements ActionInterface
 }
 ```
 
-**IMPORTANT:** Please note that when using custom requests in your HTTP Action, you will have access to **two request
-objects** in your action's `process()` method body: 
-
-* `$request`, which is a standard object, implementing the `ServerRequestInterface` interface, and
-* `$this->request`, which is your custom request object.
+If a route has no custom request class name declared, that route's HTTP action will be provided with an instance of
+`Noctis\KickStart\Http\Request\Request` class.
 
 ## Available Methods
 
-A custom HTTP request class offers some of the most commonly uses methods defined by the 
-`Psr\Http\Message\ServerRequestInterface` interface, i.e.:
+A custom HTTP request class, as it extends the `Noctis\KickStart\Http\Request\Request`, offers implementation of all the 
+methods the `Psr\Http\Message\ServerRequestInterface` interface declares, i.e.:
 
 * `getAttribute()` - for fetching custom attributes set by HTTP middlewares or named route parameters,
 * `getParsedBody()` - for fetching the request's body (used in requests sent _via_ HTTP's `POST` method),
 * `getQueryParams()` - for fetching request's query parameters (used in requests sent _via_ HTTP's `GET` method),
 * `getUploadedFiles()` - for getting a list of uploaded files, if there were any.
 
-Every custom HTTP request object offers one additional, helper method, for fetching request parameters: `get()`. This
-method will try and return a parameter, of the given name, checking the request's contents in the following order:
-
-* attributes,
-* body (`POST`),
-* query params (`GET`).
-
-If nothing with the given name is found in the request, the `get()` method will return:
-
-* the value provided as the method's second argument, or
-* `null` if no second argument was given.
-
 ## Custom Methods
 
 A custom request class can have its own, additional methods available. For example, if one of your request query 
-parameters is a string representing a date, you could call `get()` like this:
+parameters is a string representing a date, named `date`, you could fetch it like so:
 
 ```php
 /** @var string */
-$date = $this->request
-    ->get('date');
+$date = $this->getQueryParams()['date'];
 ```
 
 or you could add the following method to your custom request class:
 
 ```php
-public function getDate(): \DateTimeImmutable
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Request;
+
+use Noctis\KickStart\Http\Request\Request;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class DummyRequest extends Request implements ServerRequestInterface
 {
-    return new \DateTimeImmutable(
-        $this->get('date')
-    );
+    // ...
+
+    public function getDate(): \DateTimeImmutable
+    {
+        return new \DateTimeImmutable(
+            $this->getQueryParams()['date']
+        );
+    }
 }
+
 ```
 
-and then use it like so:
+and then use it like so, in your action:
 
 ```php
-/** @var \DateTimeImmutable */
-$date = $this->request
-    ->getDate();
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Action;
+
+use App\Http\Request\DummyRequest;
+use Noctis\KickStart\Http\Action\ActionInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class DummyAction implements ActionInterface
+{
+    // ...
+
+    /**
+     * @param DummyRequest $request
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        /** @var \DateTimeImmutable $date */
+        $date = $request->getDate();
+
+        // ...
+    }
+}
 ```
-
-

--- a/docs/Folders.md
+++ b/docs/Folders.md
@@ -89,9 +89,8 @@ You can read more about guards [here](HTTP.md) (`Middleware` section, at the bot
 
 ### src/Http/Request
 
-This folder contains optional classes representing requests, to be passed (as dependencies) to HTTP actions. A standard
-Request class contains a generic `get()` getter method for fetching request's parameters, while a custom one may contain
-parameter-specific ones, e.g. `getDate()`.
+This folder contains optional classes representing requests, to be passed to HTTP actions, instead of Kickstart's 
+standard request object. A custom request class may, for example contain parameter-specific getters, e.g. `getDate()`.
 
 ### src/Http/Routing
 

--- a/src/Http/Action/DummyAction.php
+++ b/src/Http/Action/DummyAction.php
@@ -16,23 +16,22 @@ final class DummyAction implements ActionInterface
 {
     use RenderTrait;
 
-    private DummyRequest $request;
-
-    public function __construct(DummyRequest $request, HtmlResponseFactoryInterface $htmlResponseFactory)
+    public function __construct(HtmlResponseFactoryInterface $htmlResponseFactory)
     {
-        $this->request = $request;
         $this->htmlResponseFactory = $htmlResponseFactory;
     }
 
+    /**
+     * @param DummyRequest $request
+     */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): HtmlResponse
     {
-        $name = $this->request
-            ->getQueryParams()['name'] ?? 'World';
+        /** @var string $name */
+        $name = $request->getQueryParams()['name'] ?? 'World';
 
         return $this->render('dummy.html.twig', [
             'name' => $name,
-            'foo'  => $this->request
-                ->getFoo()
+            'foo'  => $request->getFoo()
         ]);
     }
 }

--- a/src/Http/Request/DummyRequest.php
+++ b/src/Http/Request/DummyRequest.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace App\Http\Request;
 
-use Noctis\KickStart\Http\Request\AbstractRequest;
+use Noctis\KickStart\Http\Request\Request;
+use Psr\Http\Message\ServerRequestInterface;
 
-final class DummyRequest extends AbstractRequest
+final class DummyRequest extends Request implements ServerRequestInterface
 {
     public function getFoo(): string
     {

--- a/src/Http/Routing/routes.php
+++ b/src/Http/Routing/routes.php
@@ -12,7 +12,9 @@ return [
 
     // Example route: the `id` parameter is required and must be a number
     //Route::get('/user/{id:\d+}', DummyAction::class),
+    // The `id` parameter can be fetched in action by calling `$request->getAttribute('id')`
 
     // Example route: the `title` parameter is required (as is the `/` in front of it)
     //Route::get('/project[/{title}]', DummyAction::class),
+    // The `title` parameter can be fetched in action by calling `$request->getAttribute('title')`
 ];

--- a/src/Http/Routing/routes.php
+++ b/src/Http/Routing/routes.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 use App\Http\Action\DummyAction;
 use App\Http\Middleware\Guard\DummyGuard;
+use App\Http\Request\DummyRequest;
 use Noctis\KickStart\Http\Routing\Route;
 
 return [
-    Route::get('/', DummyAction::class, [DummyGuard::class]),
+    Route::get('/', DummyAction::class, [DummyGuard::class], DummyRequest::class),
 
     // Example route: the `id` parameter is required and must be a number
     //Route::get('/user/{id:\d+}', DummyAction::class),


### PR DESCRIPTION
Custom request classes will now implements the PSR-7's ServerRequestInterface and will therefore be inserted into an action through its execute() method, instead of through the action's constructor.

See: https://github.com/Noctis/kickstart/pull/58