### PR TITLE
Bugfix: Configuration Options Could be Provided Empty

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -19,8 +19,11 @@ $dotenv->required([
     'db_pass',
     'db_name',
     'db_port'
-]);
-$dotenv->required('db_port')->isInteger();
+])
+->notEmpty();
+$dotenv->required('db_port')
+    ->notEmpty()
+    ->isInteger();
 
 $whoops = new Whoops();
 if (Configuration::isProduction()) {


### PR DESCRIPTION
Configuration options (`.env`) that were declared as required, could be provided empty, e.g.:

```dotenv
db_name=
```