### PR TITLE
Bugfix: Trying to Debug in Twig Template While in Prod. Environment Crashes the App

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -624,12 +624,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Noctis/kickstart.git",
-                "reference": "d09f27f1783eebd472d2f79f5c6feffa4fed60f7"
+                "reference": "b30bd0ee1d922245c8be0c6ae35a98ba043bec3a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Noctis/kickstart/zipball/d09f27f1783eebd472d2f79f5c6feffa4fed60f7",
-                "reference": "d09f27f1783eebd472d2f79f5c6feffa4fed60f7",
+                "url": "https://api.github.com/repos/Noctis/kickstart/zipball/b30bd0ee1d922245c8be0c6ae35a98ba043bec3a",
+                "reference": "b30bd0ee1d922245c8be0c6ae35a98ba043bec3a",
                 "shasum": ""
             },
             "require": {
@@ -683,7 +683,7 @@
                 "issues": "https://github.com/Noctis/kickstart/issues",
                 "source": "https://github.com/Noctis/kickstart/tree/3.2.x"
             },
-            "time": "2022-07-20T11:28:50+00:00"
+            "time": "2022-07-20T12:22:36+00:00"
         },
         {
             "name": "opis/closure",


### PR DESCRIPTION
Using the `dump()` function in Twig template while the app. is running in production environment results in a crash (500).

See: https://github.com/Noctis/kickstart/pull/61