### PR TITLE
Safeguard Against Leftover `dump()` Calls in Code

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -850,12 +850,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Noctis/kickstart.git",
-                "reference": "7be34a0d13ae6f97a773a63d47e06b1febc259af"
+                "reference": "6a6af4a3972e2d4c88dd53d84172dc49ab8d7cf2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Noctis/kickstart/zipball/7be34a0d13ae6f97a773a63d47e06b1febc259af",
-                "reference": "7be34a0d13ae6f97a773a63d47e06b1febc259af",
+                "url": "https://api.github.com/repos/Noctis/kickstart/zipball/6a6af4a3972e2d4c88dd53d84172dc49ab8d7cf2",
+                "reference": "6a6af4a3972e2d4c88dd53d84172dc49ab8d7cf2",
                 "shasum": ""
             },
             "require": {
@@ -914,7 +914,7 @@
                 "issues": "https://github.com/Noctis/kickstart/issues",
                 "source": "https://github.com/Noctis/kickstart/tree/4.0.x"
             },
-            "time": "2022-12-09T09:47:35+00:00"
+            "time": "2022-12-09T10:16:23+00:00"
         },
         {
             "name": "paragonie/corner",

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -12,4 +12,8 @@
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>
+
+    <forbiddenFunctions>
+        <function name="dump"/>
+    </forbiddenFunctions>
 </psalm>


### PR DESCRIPTION
See: https://github.com/Noctis/kickstart/pull/82