### PR TITLE
Bugfix: Twig Renderer is not usable in console commands

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -8,6 +8,7 @@ use App\Provider\DatabaseConnectionProvider;
 use App\Provider\DummyServicesProvider;
 use App\Provider\RepositoryProvider;
 use Noctis\KickStart\Console\ConsoleApplication;
+use Noctis\KickStart\Http\Routing\RouteInterface;
 
 require_once __DIR__ . '/../bootstrap.php';
 
@@ -16,6 +17,11 @@ $app = ConsoleApplication::boot(
     new DummyServicesProvider(),
     new RepositoryProvider()
 );
+
+/** @var list<RouteInterface> $routes */
+$routes = require_once $_ENV['basepath'] . '/config/routes.php';
+$app->setRoutes($routes);
+
 $app->setCommands([
     DummyCommand::class
 ]);

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": "~8.1.0",
         "composer-runtime-api": "^2",
         "laminas/laminas-diactoros": "^2.24",
-        "noctis/kickstart": "dev-bugfix/twig-renderer-in-console-commands",
+        "noctis/kickstart": "~4.0.0",
         "paragonie/easydb": "^3.0",
         "psr/container": "^1.1|^2.0",
         "psr/http-message": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": "~8.1.0",
         "composer-runtime-api": "^2",
         "laminas/laminas-diactoros": "^2.24",
-        "noctis/kickstart": "~4.0.0",
+        "noctis/kickstart": "dev-bugfix/twig-renderer-in-console-commands",
         "paragonie/easydb": "^3.0",
         "psr/container": "^1.1|^2.0",
         "psr/http-message": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2805726e625415941d65d0be494da819",
+    "content-hash": "f95451ce30cf6d7f30d9d9e3b8fc52fd",
     "packages": [
         {
             "name": "azjezz/psl",
@@ -843,16 +843,16 @@
         },
         {
             "name": "noctis/kickstart",
-            "version": "dev-bugfix/twig-renderer-in-console-commands",
+            "version": "4.0.0-RC5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Noctis/kickstart.git",
-                "reference": "683c67c2cfa72325518ae58a8565abbee7318c2e"
+                "reference": "70375bdab8e6429fd1fc3c741a537de23cecfed9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Noctis/kickstart/zipball/683c67c2cfa72325518ae58a8565abbee7318c2e",
-                "reference": "683c67c2cfa72325518ae58a8565abbee7318c2e",
+                "url": "https://api.github.com/repos/Noctis/kickstart/zipball/70375bdab8e6429fd1fc3c741a537de23cecfed9",
+                "reference": "70375bdab8e6429fd1fc3c741a537de23cecfed9",
                 "shasum": ""
             },
             "require": {
@@ -909,9 +909,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Noctis/kickstart/issues",
-                "source": "https://github.com/Noctis/kickstart/tree/bugfix/twig-renderer-in-console-commands"
+                "source": "https://github.com/Noctis/kickstart/tree/4.0.0-RC5"
             },
-            "time": "2023-03-27T14:37:32+00:00"
+            "time": "2023-04-03T10:58:21+00:00"
         },
         {
             "name": "paragonie/corner",
@@ -4593,7 +4593,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "noctis/kickstart": 20,
         "roave/security-advisories": 20
     },
     "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f95451ce30cf6d7f30d9d9e3b8fc52fd",
+    "content-hash": "2805726e625415941d65d0be494da819",
     "packages": [
         {
             "name": "azjezz/psl",
@@ -843,16 +843,16 @@
         },
         {
             "name": "noctis/kickstart",
-            "version": "4.0.0-RC4",
+            "version": "dev-bugfix/twig-renderer-in-console-commands",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Noctis/kickstart.git",
-                "reference": "1ba71e392036dae229008238540c0d8a27b49d03"
+                "reference": "1ae13d7904d4707258abe05b94437735d3364070"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Noctis/kickstart/zipball/1ba71e392036dae229008238540c0d8a27b49d03",
-                "reference": "1ba71e392036dae229008238540c0d8a27b49d03",
+                "url": "https://api.github.com/repos/Noctis/kickstart/zipball/1ae13d7904d4707258abe05b94437735d3364070",
+                "reference": "1ae13d7904d4707258abe05b94437735d3364070",
                 "shasum": ""
             },
             "require": {
@@ -909,9 +909,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Noctis/kickstart/issues",
-                "source": "https://github.com/Noctis/kickstart/tree/4.0.0-RC4"
+                "source": "https://github.com/Noctis/kickstart/tree/bugfix/twig-renderer-in-console-commands"
             },
-            "time": "2023-03-15T11:50:51+00:00"
+            "time": "2023-03-23T09:55:04+00:00"
         },
         {
             "name": "paragonie/corner",
@@ -4593,6 +4593,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "noctis/kickstart": 20,
         "roave/security-advisories": 20
     },
     "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -847,12 +847,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Noctis/kickstart.git",
-                "reference": "49291c9a477a21c08eecdd4c4bc158fb99b51923"
+                "reference": "683c67c2cfa72325518ae58a8565abbee7318c2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Noctis/kickstart/zipball/49291c9a477a21c08eecdd4c4bc158fb99b51923",
-                "reference": "49291c9a477a21c08eecdd4c4bc158fb99b51923",
+                "url": "https://api.github.com/repos/Noctis/kickstart/zipball/683c67c2cfa72325518ae58a8565abbee7318c2e",
+                "reference": "683c67c2cfa72325518ae58a8565abbee7318c2e",
                 "shasum": ""
             },
             "require": {
@@ -911,7 +911,7 @@
                 "issues": "https://github.com/Noctis/kickstart/issues",
                 "source": "https://github.com/Noctis/kickstart/tree/bugfix/twig-renderer-in-console-commands"
             },
-            "time": "2023-03-27T10:05:03+00:00"
+            "time": "2023-03-27T14:37:32+00:00"
         },
         {
             "name": "paragonie/corner",

--- a/composer.lock
+++ b/composer.lock
@@ -847,12 +847,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Noctis/kickstart.git",
-                "reference": "1ae13d7904d4707258abe05b94437735d3364070"
+                "reference": "49291c9a477a21c08eecdd4c4bc158fb99b51923"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Noctis/kickstart/zipball/1ae13d7904d4707258abe05b94437735d3364070",
-                "reference": "1ae13d7904d4707258abe05b94437735d3364070",
+                "url": "https://api.github.com/repos/Noctis/kickstart/zipball/49291c9a477a21c08eecdd4c4bc158fb99b51923",
+                "reference": "49291c9a477a21c08eecdd4c4bc158fb99b51923",
                 "shasum": ""
             },
             "require": {
@@ -911,7 +911,7 @@
                 "issues": "https://github.com/Noctis/kickstart/issues",
                 "source": "https://github.com/Noctis/kickstart/tree/bugfix/twig-renderer-in-console-commands"
             },
-            "time": "2023-03-23T09:55:04+00:00"
+            "time": "2023-03-27T10:05:03+00:00"
         },
         {
             "name": "paragonie/corner",

--- a/docs/cookbook/Custom_Console_Command_Loader.md
+++ b/docs/cookbook/Custom_Console_Command_Loader.md
@@ -16,6 +16,7 @@ declare(strict_types=1);
 use App\Console\Command\DummyCommand;
 use App\Console\Loader\CustomConsoleCommandLoader;
 use Noctis\KickStart\Console\ConsoleApplication;
+use Noctis\KickStart\Http\Routing\RouteInterface;
 use Noctis\KickStart\Service\Container\SettableContainerInterface;
 use Symfony\Component\Console\CommandLoader\CommandLoaderInterface;
 
@@ -24,6 +25,11 @@ require_once __DIR__ . '/../bootstrap.php';
 $app = ConsoleApplication::boot(
     // ...
 );
+
+/** @var list<RouteInterface> $routes */
+$routes = require_once $_ENV['basepath'] . '/config/routes.php';
+$app->setRoutes($routes);
+
 $app->setCommandLoaderFactory(
     function (SettableContainerInterface $container): CommandLoaderInterface {
         $commandLoader = new CustomConsoleCommandLoader($container);

--- a/docs/cookbook/Custom_Console_Command_Loader.md
+++ b/docs/cookbook/Custom_Console_Command_Loader.md
@@ -16,7 +16,7 @@ declare(strict_types=1);
 use App\Console\Command\DummyCommand;
 use App\Console\Loader\CustomConsoleCommandLoader;
 use Noctis\KickStart\Console\ConsoleApplication;
-use Psr\Container\ContainerInterface;
+use Noctis\KickStart\Service\Container\SettableContainerInterface;
 use Symfony\Component\Console\CommandLoader\CommandLoaderInterface;
 
 require_once __DIR__ . '/../bootstrap.php';
@@ -25,7 +25,7 @@ $app = ConsoleApplication::boot(
     // ...
 );
 $app->setCommandLoaderFactory(
-    function (ContainerInterface $container): CommandLoaderInterface {
+    function (SettableContainerInterface $container): CommandLoaderInterface {
         $commandLoader = new CustomConsoleCommandLoader($container);
         $commandLoader->setCommandMap([
             'dummy:command' => DummyCommand::class,
@@ -40,8 +40,8 @@ $app->run();
 The `setCustomCommandLoaderFactory()` method accepts a single argument - a callable (factory method). Said factory 
 method:
 
-* will be given one argument - an instance of a Dependency Injection container implementing the 
-  `\Psr\Container\ContainerInterface`,
+* will be given one argument - an instance of a Dependency Injection container implementing Kickstart's 
+  `\Noctis\KickStart\Service\Container\SettableContainerInterface`,
 * must return an instance of a class implementing the `Symfony\Component\Console\CommandLoader\CommandLoaderInterface`.
 
 Here's an example of a custom console command loader class, implementing the aforementioned interface:
@@ -53,21 +53,19 @@ declare(strict_types=1);
 
 namespace App\Console\Loader;
 
-use Psr\Container\ContainerInterface;
+use Noctis\KickStart\Service\Container\SettableContainerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\CommandLoader\CommandLoaderInterface;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
 
 final class CustomConsoleCommandLoader implements CommandLoaderInterface
 {
-    private ContainerInterface $container;
-
     /** @var array<string, class-string<Command>>  */
     private array $commandMap = [];
 
-    public function __construct(ContainerInterface $container)
-    {
-        $this->container = $container;
+    public function __construct(
+        private readonly SettableContainerInterface $container
+    ) {
     }
 
     /**

--- a/docs/cookbook/New_Console_Command.md
+++ b/docs/cookbook/New_Console_Command.md
@@ -46,6 +46,7 @@ To add a new command, you must:
   
   use App\Console\Command\DummyCommand;
   use Noctis\KickStart\Console\ConsoleApplication;
+  use Noctis\KickStart\Http\Routing\RouteInterface;
   // ...
   
   require_once __DIR__ . '/../bootstrap.php';
@@ -53,6 +54,11 @@ To add a new command, you must:
   $app = ConsoleApplication::boot(
       //...
   );
+  
+  /** @var list<RouteInterface> $routes */
+  $routes = require_once $_ENV['basepath'] . '/config/routes.php';
+  $app->setRoutes($routes);
+  
   $app->setCommands([
       DummyCommand::class,
   ]);

--- a/docs/upgrading/3.2.3_to_4.0.0.md
+++ b/docs/upgrading/3.2.3_to_4.0.0.md
@@ -419,6 +419,52 @@ Remember to restore the:
 * list of service providers, which are now passed to the `ConsoleApplication::boot()` method, and
 * list of available commands, passed to the `ConsoleApplication::setCommands()` method!
 
+**IMPORTANT:** If your application's `bin/console` is using a 
+[custom console command loader](../cookbook/Custom_Console_Command_Loader.md):
+
+```php
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Console\CommandLoader\CommandLoaderInterface;
+use Psr\Container\ContainerInterface;
+
+// ...
+
+$app->setCommandLoaderFactory(
+    function (ContainerInterface $container): CommandLoaderInterface {
+        // ...
+    }
+);
+$app->run();
+```
+
+make sure that the factory method's `$container` property is of type 
+`\Noctis\KickStart\Service\Container\SettableContainerInterface`, not `\Psr\Container\ContainerInterface`:
+
+```php
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use Noctis\KickStart\Service\Container\SettableContainerInterface;
+use Symfony\Component\Console\CommandLoader\CommandLoaderInterface;
+
+// ...
+
+$app->setCommandLoaderFactory(
+    function (SettableContainerInterface $container): CommandLoaderInterface {
+        // ...
+    }
+);
+$app->run();
+```
+
+`SettableContainerInterface` is a super-set of `ContainerInterface`.
+
 ## Updating `templates/layout.html.twig`
 
 Open your application's `templates/layout.html.twig` file and replace the reference to Bootstrap's CSS file from

--- a/public/index.php
+++ b/public/index.php
@@ -8,12 +8,10 @@ use App\Provider\HttpMiddlewareProvider;
 use App\Provider\RepositoryProvider;
 use Noctis\KickStart\Http\Routing\RouteInterface;
 use Noctis\KickStart\Http\WebApplication;
-use Noctis\KickStart\Provider\RoutingProvider;
 
 require_once __DIR__ . '/../bootstrap.php';
 
 $app = WebApplication::boot(
-    new RoutingProvider(),
     new DatabaseConnectionProvider(),
     new HttpMiddlewareProvider(),
     new DummyServicesProvider(),
@@ -21,6 +19,7 @@ $app = WebApplication::boot(
 );
 
 /** @var list<RouteInterface> $routes */
-$routes = require_once __DIR__ . '/../config/routes.php';
+$routes = require_once $_ENV['basepath'] . '/config/routes.php';
 $app->setRoutes($routes);
+
 $app->run();


### PR DESCRIPTION
Resolves https://github.com/Noctis/kickstart-app/issues/113
See: https://github.com/Noctis/kickstart/pull/97